### PR TITLE
Fixed endpoint of testCustomers to use correct path.

### DIFF
--- a/dnb_developer.json
+++ b/dnb_developer.json
@@ -22,7 +22,7 @@
   "consumes" : [ "application/json" ],
   "produces" : [ "application/json" ],
   "paths" : {
-    "/testCustomers" : {
+    "/api/testCustomers" : {
       "get" : {
         "tags" : [ "Test_Customers", "Draft", "100" ],
         "summary" : "Test Customers",
@@ -58,7 +58,7 @@
       "get" : {
         "tags" : [ "API", "Draft", "101" ],
         "summary" : "Get API token",
-        "description" : "Returning a JWT token representing the end-consumer. You need this token for calling the `Customer`,` Accounts`, `Transactions`, `Cards` and `Payments` APIs. Find test customer SSNs under `/testCustomers`.\n\nThe JWT token has an expiry time of ten minutes. After it has expired, call the API again to get a nice and fresh token.\n\n**Authorization: AWS Signature v.4**\nWe use AWS Signatures v.4 for authorization, with AWS region `eu-west-1`. If you're using Postman, the authorization header will be automatically generated when you send the request. For detailed information, we recommend [AWS's own documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html).  \n\n**Tip for Postman users:** \nHave a look at our Postman collection which is available on Github as well as code examples: https://github.com/DNBbank/getting-started/. Will make your life a little sweeter.",
+        "description" : "Returning a JWT token representing the end-consumer. You need this token for calling the `Customer`,` Accounts`, `Transactions`, `Cards` and `Payments` APIs. Find test customer SSNs under `/api/testCustomers`.\n\nThe JWT token has an expiry time of ten minutes. After it has expired, call the API again to get a nice and fresh token.\n\n**Authorization: AWS Signature v.4**\nWe use AWS Signatures v.4 for authorization, with AWS region `eu-west-1`. If you're using Postman, the authorization header will be automatically generated when you send the request. For detailed information, we recommend [AWS's own documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html).  \n\n**Tip for Postman users:** \nHave a look at our Postman collection which is available on Github as well as code examples: https://github.com/DNBbank/getting-started/. Will make your life a little sweeter.",
         "operationId" : "getApiToken",
         "produces" : [ "application/json" ],
         "parameters" : [ {


### PR DESCRIPTION
While testing I noticed that the endpoint for testCustomers is wrong in the documentation at https://developer.dnb.no/#/Documentation

If you use `/testCustomers` as the endpoint you will only receive the error message "Forbidden":

```json
{
    "message": "Forbidden"
}
```

After some trial and error, I managed to figure out that the correct endpoint is `/api/testCustomers`, not `/testCustomers`.